### PR TITLE
Update config.go

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,13 +24,16 @@ type Config struct {
 
 func init() {
 	home, _ := homedir.Dir()
-	// 默认的配置文件名称
-	configFilename := ".lightsocks.json"
 	// 如果用户有传配置文件，就使用用户传入的配置文件
 	if len(os.Args) == 2 {
-		configFilename = os.Args[1]
+		configPath = os.Args[1]
+		fmt.Println("接受传入的配置文件路径 %s", configPath)
+	} else {
+		// 默认的配置文件名称
+		configFilename := "lightsocks.json"
+		configPath = path.Join(home, configFilename)
+		fmt.Println("未传输路径参数，尝试生成配置文件 %s", configPath)
 	}
-	configPath = path.Join(home, configFilename)
 }
 
 // 保存配置到配置文件


### PR DESCRIPTION
新的配置文件操作方法，使用参数优先，并且使用绝对路径保证配置文件可以不存放到主目录。同时更改了配置文件的名称，配置文件将不默认隐藏。同时如果指定的文件不存在将被按照程序原逻辑创建。
此版本的目的是为了兼容部分用户不希望使用主目录或隐藏的文件做配置文件而进行的简单改写，此版本并不是一个完整的解决方法，本应再加入一个在程序目录下创建/读取配置的代码来完善此功能，以及实现无配置运行，所有配置文件的内容通过命令行参数传递。
（刚接触Golang，现在只会这么多）